### PR TITLE
Remove Ruff pyugrade keep-runtime-annotations

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -36,13 +36,13 @@ ignore = [
     "D411",  # Missing blank line before section
     "E501",  # line too long
     "E731",  # do not assign a lambda expression, use a def
+    # keep-runtime-annotations
+    'UP006', # Non PEP585 annotations
+    'UP007', # Non PEP604 annotations
 ]
 
 [flake8-pytest-style]
 fixture-parentheses = false
-
-[pyupgrade]
-keep-runtime-typing = true
 
 [mccabe]
 max-complexity = 25


### PR DESCRIPTION
Ignore UP006 and UP007 instead.
This is a breaking change introduced by Ruff 0.0.268.

More details: https://github.com/charliermarsh/ruff/blob/main/BREAKING_CHANGES.md